### PR TITLE
Fix gpt.defineUnit order issue & release 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sortable/ads",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "dist/sortableads.js",
   "types": "src/types.d.ts",

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -220,10 +220,10 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
           });
         });
 
-        const gptUnits = adServer.getUnits(activeAdConfigs);
+        const gptUnits = adServer.getOrDefineUnits(activeAdConfigs);
 
         this.HBs.forEach(hb => {
-          hb.beforeRequestAdServer(hb.getUnits(activeAdConfigs));
+          hb.beforeRequestAdServer(hb.getOrDefineUnits(activeAdConfigs));
         });
 
         adServer.requestAdServer(gptUnits);
@@ -258,7 +258,7 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
           return;
         }
 
-        hb.requestBids(hb.getUnits(activeAdConfigs), timeout, done);
+        hb.requestBids(hb.getOrDefineUnits(activeAdConfigs), timeout, done);
       });
     });
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -220,11 +220,13 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
           });
         });
 
+        const gptUnits = adServer.getUnits(activeAdConfigs);
+
         this.HBs.forEach(hb => {
           hb.beforeRequestAdServer(hb.getUnits(activeAdConfigs));
         });
 
-        adServer.requestAdServer(adServer.getUnits(activeAdConfigs));
+        adServer.requestAdServer(gptUnits);
       });
     });
 

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -24,7 +24,7 @@ describe('Service', () => {
     };
     const service = new Service(emitter, plugin);
 
-    service.getUnits(adConfigs);
+    service.getOrDefineUnits(adConfigs);
 
     assert.equal(calls, 2);
   });
@@ -55,7 +55,7 @@ describe('Service', () => {
     };
     const service = new Service(emitter, plugin);
 
-    service.requestBids(service.getUnits(adConfigs), 10, () => {/** noop */});
+    service.requestBids(service.getOrDefineUnits(adConfigs), 10, () => {/** noop */});
 
     assert.equal(calls, 1);
   });
@@ -85,7 +85,7 @@ describe('Service', () => {
     };
     const service = new Service(emitter, plugin);
 
-    service.requestAdServer(service.getUnits(adConfigs));
+    service.requestAdServer(service.getOrDefineUnits(adConfigs));
 
     assert.equal(calls, 1);
   });

--- a/src/service.ts
+++ b/src/service.ts
@@ -62,7 +62,7 @@ export default class Service<T> {
     }
   }
 
-  public getUnits(adConfigs: SortableAds.AdConfig[]): T[] {
+  public getOrDefineUnits(adConfigs: SortableAds.AdConfig[]): T[] {
     if (!this.ready) {
       return [];
     }

--- a/src/sortableads.ts
+++ b/src/sortableads.ts
@@ -24,7 +24,7 @@ if (!sortableads.apiReady) {
   sortableads.removeEventListener = (x, y) => manager.removeEventListener(x, y);
 
   sortableads.apiReady = true;
-  sortableads.version = '0.0.4';
+  sortableads.version = '0.0.5';
 
   manager.tryCatch('debug', debug);
 


### PR DESCRIPTION
- It should do ad server's `defineUnit` before `beforeRequestAdServer`.
- release 0.0.5