### PR TITLE
Extend api usage

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,6 +1,6 @@
 import EventEmitter from './event-emitter';
 import Service from './service';
-import { isArray, once } from './util';
+import { isArray, isString, once } from './util';
 
 /**
  * Manager is the class which implements the public Ads Manager API.
@@ -60,6 +60,12 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
       if (!isArray(elementIds)) {
         elementIds = [elementIds];
       }
+      if (!elementIds.every(isString)) {
+        this.emitEvent('warning', {
+          message: 'requestAds with non-string argument',
+        });
+        elementIds = elementIds.filter(isString);
+      }
       this.emitEvent('requestAds', { elementIds });
       elementIds.forEach(elementId => {
         this.requestQueue[elementId] = true;
@@ -77,6 +83,12 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
     this.tryCatch('destroyAds', () => {
       if (!isArray(elementIds)) {
         elementIds = [elementIds];
+      }
+      if (!elementIds.every(isString)) {
+        this.emitEvent('warning', {
+          message: 'destroyAds with non-string argument',
+        });
+        elementIds = elementIds.filter(isString);
       }
       this.emitEvent('destroyAds', { elementIds });
       elementIds.forEach(elementId => {

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,6 +1,6 @@
 import EventEmitter from './event-emitter';
 import Service from './service';
-import { once } from './util';
+import { isArray, once } from './util';
 
 /**
  * Manager is the class which implements the public Ads Manager API.
@@ -36,8 +36,11 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
     this.emitEvent('updateSetting', { name, previousValue, updatedValue });
   }
 
-  public defineAds(adConfigs: SortableAds.AdConfig[]): void {
+  public defineAds(adConfigs: SortableAds.AdConfig | SortableAds.AdConfig[]): void {
     this.tryCatch('defineAds', () => {
+      if (!isArray(adConfigs)) {
+        adConfigs = [adConfigs];
+      }
       this.emitEvent('defineAds', { adConfigs });
       for (const adConfig of adConfigs) {
         this.adConfigMap[adConfig.elementId] = adConfig;
@@ -52,8 +55,11 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
    *
    * @param elementIds The ids for the elements that requested ads should fill
    */
-  public requestAds(elementIds: string[]): void {
+  public requestAds(elementIds: string | string[]): void {
     this.tryCatch('requestAds', () => {
+      if (!isArray(elementIds)) {
+        elementIds = [elementIds];
+      }
       this.emitEvent('requestAds', { elementIds });
       elementIds.forEach(elementId => {
         this.requestQueue[elementId] = true;
@@ -67,8 +73,11 @@ export default class Manager extends EventEmitter<SortableAds.EventMap> {
     return Object.keys(this.requestedAds);
   }
 
-  public destroyAds(elementIds: string[]) {
+  public destroyAds(elementIds: string | string[]) {
     this.tryCatch('destroyAds', () => {
+      if (!isArray(elementIds)) {
+        elementIds = [elementIds];
+      }
       this.emitEvent('destroyAds', { elementIds });
       elementIds.forEach(elementId => {
         delete this.requestedAds[elementId];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -149,12 +149,12 @@ declare namespace SortableAds {
     /**
      * Define ads with provided configuration
      */
-    defineAds(adConfigs: AdConfig[]): void;
+    defineAds(adConfigs: AdConfig | AdConfig[]): void;
 
     /**
      * Request ads for provided element ids
      */
-    requestAds(elementIds: string[]): void;
+    requestAds(elementIds: string | string[]): void;
 
     /**
      * Get the list of requested but not destroyed element ids
@@ -164,7 +164,7 @@ declare namespace SortableAds {
     /**
      * Destroy ads for provided element ids
      */
-    destroyAds(elementIds: string[]): void;
+    destroyAds(elementIds: string | string[]): void;
 
     /**
      * Indicate that it's a new page

--- a/src/util.ts
+++ b/src/util.ts
@@ -56,3 +56,7 @@ export const allEvents: SortableAds.EventKey[] = [
  'requestUndefinedAdWarning',
  'requestBidsTimeout',
 ];
+
+export function isArray(x: any): x is any[] {
+  return Object.prototype.toString.call(x) === '[object Array]';
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -60,3 +60,7 @@ export const allEvents: SortableAds.EventKey[] = [
 export function isArray(x: any): x is any[] {
   return Object.prototype.toString.call(x) === '[object Array]';
 }
+
+export function isString(x: any): x is string {
+  return Object.prototype.toString.call(x) === '[object String]';
+}


### PR DESCRIPTION
Auto convert non-array args to array for
- `sortableads.defineAds`
- `sortableads.requestAds`
- `sortableads.destroyAds`

Reason: people may use `sortableads.requestAds('xxx')` instead of `sortableads.requestAds(['xxx'])` at first. Instead of log warning and ask people to fix it, we may just handle this case properly.