### PR TITLE
Migrate from gpt sample

### DIFF
--- a/docs/_media/migration/gpt-sample.html
+++ b/docs/_media/migration/gpt-sample.html
@@ -33,15 +33,15 @@
 <body>
   <div id="div-gpt-ad-123456789-0" style="width: 728px; height: 90px">
     <script>
-      googletag.cmd.push(function() {
-        googletag.display("div-gpt-ad-123456789-0");
+      sortableads.push(function() {
+        sortableads.requestAds(["div-gpt-ad-123456789-0"]);
       });
     </script>
   </div>
     <div id="div-gpt-ad-123456789-1">
     <script>
-      googletag.cmd.push(function() {
-        googletag.display("div-gpt-ad-123456789-1");
+      sortableads.push(function() {
+        sortableads.requestAds(["div-gpt-ad-123456789-1"]);
       });
     </script>
   </div>

--- a/docs/_media/migration/gpt-sample.html
+++ b/docs/_media/migration/gpt-sample.html
@@ -14,6 +14,12 @@
   googletag.cmd.push(function() {
     googletag.pubads().set("adsense_background_color", "FFFFFF");
   });
+  sortableads.push(function() {
+    sortableads.useGPTAsync({
+      disableInitialLoad: false,
+      enableSingleRequest: true,
+    });
+  });
 </script>
 <script>
   googletag.cmd.push(function() {
@@ -25,8 +31,6 @@
       .setTargeting("gender", "male")
       .setTargeting("age", "20-30");
     googletag.pubads().setTargeting("topic","basketball");
-    googletag.pubads().enableSingleRequest();
-    googletag.enableServices();
   });
 </script>
 </head>

--- a/docs/_media/migration/gpt-sample.html
+++ b/docs/_media/migration/gpt-sample.html
@@ -1,8 +1,12 @@
 <html>
 <head>
+<!-- This CDN file is for demo only. Do not use it in production. -->
+<script async="async" src="https://cdn.jsdelivr.net/npm/@sortable/ads/dist/sortableads.min.js">
+</script>
 <script async="async" src="https://www.googletagservices.com/tag/js/gpt.js">
 </script>
 <script>
+  var sortableads = sortableads || [];
   var googletag = googletag || {};
   googletag.cmd = googletag.cmd || [];
 </script>

--- a/docs/_media/migration/gpt-sample.html
+++ b/docs/_media/migration/gpt-sample.html
@@ -11,10 +11,11 @@
   googletag.cmd = googletag.cmd || [];
 </script>
 <script>
-  googletag.cmd.push(function() {
-    googletag.pubads().set("adsense_background_color", "FFFFFF");
-  });
   sortableads.push(function() {
+    googletag.cmd.push(function() {
+      googletag.pubads().set("adsense_background_color", "FFFFFF");
+      googletag.pubads().setTargeting("topic","basketball");
+    });
     sortableads.useGPTAsync({
       disableInitialLoad: false,
       enableSingleRequest: true,
@@ -30,7 +31,6 @@
       .addService(googletag.pubads())
       .setTargeting("gender", "male")
       .setTargeting("age", "20-30");
-    googletag.pubads().setTargeting("topic","basketball");
   });
 </script>
 </head>

--- a/docs/_media/migration/gpt-sample.html
+++ b/docs/_media/migration/gpt-sample.html
@@ -40,6 +40,7 @@
         }
       }
     }]);
+    sortableads.start();
   });
 </script>
 </head>

--- a/docs/_media/migration/gpt-sample.html
+++ b/docs/_media/migration/gpt-sample.html
@@ -20,17 +20,26 @@
       disableInitialLoad: false,
       enableSingleRequest: true,
     });
-  });
-</script>
-<script>
-  googletag.cmd.push(function() {
-    googletag.defineSlot("/19968336/header-bid-tag-0", [728, 90], "div-gpt-ad-123456789-0")
-      .addService(googletag.pubads())
-      .setTargeting("interests", ["sports", "music", "movies"]);
-    googletag.defineSlot("/19968336/header-bid-tag1", [[468, 60], [728, 90], [300, 250]], "div-gpt-ad-123456789-1")
-      .addService(googletag.pubads())
-      .setTargeting("gender", "male")
-      .setTargeting("age", "20-30");
+    sortableads.defineAds([{
+      elementId: "div-gpt-ad-123456789-0",
+      sizes: [728, 90],
+      GPT: {
+        adUnitPath: "/19968336/header-bid-tag-0",
+        targeting: {
+          "interests": ["sports", "music", "movies"]
+        }
+      }
+    }, {
+      elementId: "div-gpt-ad-123456789-1",
+      sizes: [[468, 60], [728, 90], [300, 250]],
+      GPT: {
+        adUnitPath: "/19968336/header-bid-tag1",
+        targeting: {
+          "gender": "male",
+          "age": "20-30"
+        }
+      }
+    }]);
   });
 </script>
 </head>


### PR DESCRIPTION
GPT sample is from https://support.google.com/dfp_premium/answer/1638622

Step-by-step guide about migrating from standard GPT usage to Ads Manager.
* Step 1: load async sortableads script and initialize `sortableads` global variable.
* Step 2: replace `googletag.display` with `sortableads.requestAds` API
* Step 3: replace `googletag.pubads().enableSingleRequest()` and `googletag.enableServices()` with built-in GPT plugin via `sortableads.useGPTAsync()`.
* Step 4: move googletag page-level configuration before loading GPT plugin (`sortableads.useGPTAsync`).
* Step 5: replace `googletag.defineSlot` with `sortableads.deineAds` for ads registration.
* Step 6: call `sortableads.start()` to start serving ads

You can check them by each commits. Or you can see [all changes](https://github.com/sortable/ads/pull/38/files) at file-level.