### PR TITLE
Migrate from prebid refresh example

### DIFF
--- a/docs/_media/migration/prebid-refresh-example.html
+++ b/docs/_media/migration/prebid-refresh-example.html
@@ -117,9 +117,6 @@
     <p><button onclick="refreshBid()">Refresh Ad Unit</button></p>
 
     <div id='div-gpt-ad-1438287399331-0'>
-      <script type='text/javascript'>
-       googletag.cmd.push(function() { googletag.display('div-gpt-ad-1438287399331-0'); });
-      </script>
     </div>
 
   </body>

--- a/docs/_media/migration/prebid-refresh-example.html
+++ b/docs/_media/migration/prebid-refresh-example.html
@@ -39,6 +39,10 @@
        pbjsTargetEl.insertBefore(pbjsEl, pbjsTargetEl.firstChild);
      })();
 
+     sortableads.push(function() {
+       sortableads.useGPTAsync();
+     });
+
      pbjs.que.push(function() {
        var adUnits = [{
          code: 'div-gpt-ad-1438287399331-0',
@@ -88,10 +92,6 @@
        rightSlot = googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1438287399331-0').addService(googletag.pubads());
 
        topSlot = googletag.defineSlot('/19968336/header-bid-tag1', [[728, 90], [970, 90]], 'div-gpt-ad-1438287399331-1').addService(googletag.pubads());
-
-       googletag.pubads().disableInitialLoad();
-       googletag.pubads().enableSingleRequest();
-       googletag.enableServices();
      });
 
      function refreshBid() {

--- a/docs/_media/migration/prebid-refresh-example.html
+++ b/docs/_media/migration/prebid-refresh-example.html
@@ -1,6 +1,9 @@
 <html>
   <head>
     <title>Prebid.js - Individual Ad Unit Refresh Example</title>
+    <!-- This CDN file is for demo only. Do not use it in production. -->
+    <script src="https://cdn.jsdelivr.net/npm/@sortable/ads/dist/sortableads.min.js" async></script>
+    <script> var sortableads = sortableads || []; </script>
     <script>
      var PREBID_TIMEOUT = 1000;
 

--- a/docs/_media/migration/prebid-refresh-example.html
+++ b/docs/_media/migration/prebid-refresh-example.html
@@ -43,41 +43,50 @@
        sortableads.useGPTAsync();
        sortableads.usePrebidForGPTAsync();
        sortableads.set('bidderTimeout', PREBID_TIMEOUT);
+       sortableads.defineAds([{
+         elementId: 'div-gpt-ad-1438287399331-0',
+         GPT: {
+           adUnitPath: '/19968336/header-bid-tag-0',
+           sizes: [[300, 250], [300, 600]]
+         },
+         prebid: {
+           mediaTypes: {
+             banner: {
+               sizes: [[300, 250], [300, 600]],
+             }
+           },
+           bids: [{
+             bidder: 'appnexus',
+             params: { placementId: '10433394' }
+           }, {
+             bidder: 'pubmatic',
+             params: {
+               publisherId: 'TO ADD',
+               adSlot: 'TO ADD'
+             }
+           }]
+         }
+       }, {
+         elementId: 'div-gpt-ad-1438287399331-1',
+         GPT: {
+           adUnitPath: '/19968336/header-bid-tag1',
+           sizes: [[728, 90], [970, 90]]
+         },
+         prebid: {
+           mediaTypes: {
+             banner: {
+               sizes: [[728, 90], [970, 90]],
+             }
+           },
+           bids: [{
+             bidder: 'appnexus',
+             params: { placementId: '10433394' }
+           }]
+         }
+       }]);
      });
 
      pbjs.que.push(function() {
-       var adUnits = [{
-         code: 'div-gpt-ad-1438287399331-0',
-         mediaTypes: {
-           banner: {
-             sizes: [[300, 250], [300, 600]],
-           }
-         },
-         bids: [{
-           bidder: 'appnexus',
-           params: { placementId: '10433394' }
-         }, {
-           bidder: 'pubmatic',
-           params: {
-             publisherId: 'TO ADD',
-             adSlot: 'TO ADD'
-           }
-         }]
-       },{
-         code: 'div-gpt-ad-1438287399331-1',
-         mediaTypes: {
-           banner: {
-             sizes: [[728, 90], [970, 90]],
-           }
-         },
-         bids: [{
-           bidder: 'appnexus',
-           params: { placementId: '10433394' }
-         }]
-       }];
-
-       pbjs.addAdUnits(adUnits);
-
        pbjs.requestBids({
          bidsBackHandler: function(bidResponses) {
            initAdserver();
@@ -87,15 +96,6 @@
     </script>
 
     <script>
-     var rightSlot;
-     var topSlot;
-
-     googletag.cmd.push(function() {
-       rightSlot = googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1438287399331-0').addService(googletag.pubads());
-
-       topSlot = googletag.defineSlot('/19968336/header-bid-tag1', [[728, 90], [970, 90]], 'div-gpt-ad-1438287399331-1').addService(googletag.pubads());
-     });
-
      function refreshBid() {
        sortableads.push(function() {
          sortableads.requestAds(['div-gpt-ad-1438287399331-0']);

--- a/docs/_media/migration/prebid-refresh-example.html
+++ b/docs/_media/migration/prebid-refresh-example.html
@@ -41,6 +41,8 @@
 
      sortableads.push(function() {
        sortableads.useGPTAsync();
+       sortableads.usePrebidForGPTAsync();
+       sortableads.set('bidderTimeout', PREBID_TIMEOUT);
      });
 
      pbjs.que.push(function() {
@@ -95,15 +97,8 @@
      });
 
      function refreshBid() {
-       pbjs.que.push(function() {
-         pbjs.requestBids({
-           timeout: PREBID_TIMEOUT,
-           adUnitCodes: ['div-gpt-ad-1438287399331-0'],
-           bidsBackHandler: function() {
-             pbjs.setTargetingForGPTAsync(['div-gpt-ad-1438287399331-0']);
-             googletag.pubads().refresh([rightSlot]);
-           }
-         });
+       sortableads.push(function() {
+         sortableads.requestAds(['div-gpt-ad-1438287399331-0']);
        });
      }
     </script>

--- a/docs/_media/migration/prebid-refresh-example.html
+++ b/docs/_media/migration/prebid-refresh-example.html
@@ -84,6 +84,7 @@
            }]
          }
        }]);
+       sortableads.start();
      });
 
      pbjs.que.push(function() {

--- a/docs/_media/migration/prebid-refresh-example.html
+++ b/docs/_media/migration/prebid-refresh-example.html
@@ -5,30 +5,16 @@
     <script src="https://cdn.jsdelivr.net/npm/@sortable/ads/dist/sortableads.min.js" async></script>
     <script> var sortableads = sortableads || []; </script>
     <script>
-     var PREBID_TIMEOUT = 1000;
-
-     var googletag = googletag || {};
-     googletag.cmd = googletag.cmd || [];
-
-     function initAdserver() {
-       if (pbjs.initAdserverSet) return;
-       (function() {
-         var gads = document.createElement('script');
-         gads.async = true;
-         gads.type = 'text/javascript';
-         var useSSL = 'https:' == document.location.protocol;
-         gads.src = (useSSL ? 'https:' : 'http:') +
-                    '//www.googletagservices.com/tag/js/gpt.js';
-         var node = document.getElementsByTagName('script')[0];
-         node.parentNode.insertBefore(gads, node);
-       })();
-       pbjs.initAdserverSet = true;
-     };
-
-     setTimeout(initAdserver, PREBID_TIMEOUT);
-
-     var pbjs = pbjs || {};
-     pbjs.que = pbjs.que || [];
+     (function() {
+       var gads = document.createElement('script');
+       gads.async = true;
+       gads.type = 'text/javascript';
+       var useSSL = 'https:' == document.location.protocol;
+       gads.src = (useSSL ? 'https:' : 'http:') +
+                  '//www.googletagservices.com/tag/js/gpt.js';
+       var node = document.getElementsByTagName('script')[0];
+       node.parentNode.insertBefore(gads, node);
+     })();
 
      (function() {
        var pbjsEl = document.createElement("script");
@@ -42,7 +28,7 @@
      sortableads.push(function() {
        sortableads.useGPTAsync();
        sortableads.usePrebidForGPTAsync();
-       sortableads.set('bidderTimeout', PREBID_TIMEOUT);
+       sortableads.set('bidderTimeout', 1000);
        sortableads.defineAds([{
          elementId: 'div-gpt-ad-1438287399331-0',
          GPT: {
@@ -85,14 +71,6 @@
          }
        }]);
        sortableads.start();
-     });
-
-     pbjs.que.push(function() {
-       pbjs.requestBids({
-         bidsBackHandler: function(bidResponses) {
-           initAdserver();
-         }
-       })
      });
     </script>
 


### PR DESCRIPTION
Prebid basic example is from http://prebid.org/dev-docs/examples/adunit-refresh.html

Step-by-step guide about migrating from prebid basic usage to Ads Manager.
* Step 1: load async sortableads script and initialize `sortableads` global variable.
* Step 2: remove `googletag.display`
* Step 3: replace `googletag.pubads().disableInitialLoad()`,  `googletag.pubads().enableSingleRequest()` and `googletag.enableServices()` with built-in GPT plugin via `sortableads.useGPTAsync()`.
* Step 4: replace `pbjs.requestBids` with built-in Prebid plugin via `sortableads.usePrebidForGPTAsync()`.
* Step 5: replace `googletag.defineSlot` and prebid ad units with `sortableads.deineAds` for ads registration.
* Step 6: call `sortableads.start()` to start serving ads
* Extra: clean up some unnecessary code.

You can check them by each commits. Or you can see [all changes](https://github.com/sortable/ads/pull/41/files) at file-level.